### PR TITLE
Added missing permissionsRequired to ModuleDescriptors for examples

### DIFF
--- a/hello-vertx/descriptors/ModuleDescriptor-template.json
+++ b/hello-vertx/descriptors/ModuleDescriptor-template.json
@@ -6,7 +6,8 @@
     "version" : "1.1",
       "handlers" : [ {
       "methods" : [ "GET", "POST" ],
-      "pathPattern" : "/hello"
+      "pathPattern" : "/hello",
+      "permissionsRequired": [ ]
     } ]
   } ],
   "launchDescriptor" : {

--- a/simple-perl/ModuleDescriptor.json
+++ b/simple-perl/ModuleDescriptor.json
@@ -6,7 +6,8 @@
     "version" : "1.1",
     "handlers" : [ {
       "methods" : [ "GET", "POST" ],
-      "pathPattern" : "/simple"
+      "pathPattern" : "/simple",
+      "permissionsRequired": [ ]
       } ]
     },
     {
@@ -14,7 +15,8 @@
      "version" : "1.1",
      "handlers" : [ {
        "methods" : [ "GET", "POST" ],
-       "pathPattern" : "/hello"
+       "pathPattern" : "/hello",
+       "permissionsRequired": [ ]
       } ]
     }
   ]

--- a/simple-vertx/descriptors/ModuleDescriptor-template.json
+++ b/simple-vertx/descriptors/ModuleDescriptor-template.json
@@ -6,7 +6,8 @@
     "version" : "1.1",
     "handlers" : [ {
       "methods" : [ "GET", "POST" ],
-      "pathPattern" : "/simple"
+      "pathPattern" : "/simple",
+      "permissionsRequired": [ ]
     } ]
   } ],
   "requires" : [ {


### PR DESCRIPTION
Running the hello-vertx, simple-perl, and simple-vertx examples was
failing due to missing permissionsRequired when loading module into
okapi.