### PR TITLE
Support both "http.port" and "port" property variables

### DIFF
--- a/hello-vertx/src/main/java/org/folio/sample/MainVerticle.java
+++ b/hello-vertx/src/main/java/org/folio/sample/MainVerticle.java
@@ -21,7 +21,8 @@ public class MainVerticle extends AbstractVerticle {
   @Override
   public void start(Future<Void> fut) throws IOException {
 
-    final int port = Integer.parseInt(System.getProperty("port", "8080"));
+    final int port = Integer.parseInt(
+      System.getProperty("http.port", System.getProperty("port", "8080")));
     logger.info("Starting hello "
             + ManagementFactory.getRuntimeMXBean().getName()
             + " on port " + port);

--- a/simple-vertx/src/main/java/org/folio/simple/MainVerticle.java
+++ b/simple-vertx/src/main/java/org/folio/simple/MainVerticle.java
@@ -25,7 +25,8 @@ public class MainVerticle extends AbstractVerticle {
   @Override
   public void start(Future<Void> fut) throws IOException {
 
-    final int port = Integer.parseInt(System.getProperty("port", "8080"));
+    final int port = Integer.parseInt(
+      System.getProperty("http.port", System.getProperty("port", "8080")));
     logger.info("Starting simple "
             + ManagementFactory.getRuntimeMXBean().getName()
             + " on port " + port);


### PR DESCRIPTION
"http.port" is the command-line option name that most modules
support (the RMB based modules):
https://github.com/folio-org/raml-module-builder#command-line-options