### PR TITLE
Hide unwritten section from README ToC (Logging, Health, and Metrics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For background understanding, see the
         * [Handlers](#handlers)
 * [Server-side modules](#server-side-modules)
     * [Deployment and discovery](#deployment-and-discovery)
-    * [Logging, Health, and Metrics](#logging-health-and-metrics)
+    <!-- TODO: * [Logging, Health, and Metrics](#logging-health-and-metrics) -->
     * [Writing a module](#writing-a-module)
         * [Java/Vert.x and Node.js](#javavertx-and-nodejs)
         * [Development environment](#development-environment)


### PR DESCRIPTION
It looks like the ``Logging, Health, and Metrics'' section is in the README as a TODO -- until it is written, I believe that it shouldn't be shown in the table of contents.