### PR TITLE
Fix indentation in hello-vertx Module Descriptor

### DIFF
--- a/hello-vertx/descriptors/ModuleDescriptor-template.json
+++ b/hello-vertx/descriptors/ModuleDescriptor-template.json
@@ -4,10 +4,10 @@
   "provides" : [ {
     "id" : "hello",
     "version" : "1.1",
-      "handlers" : [ {
+    "handlers" : [ {
       "methods" : [ "GET", "POST" ],
       "pathPattern" : "/hello",
-      "permissionsRequired": [ ]
+      "permissionsRequired": []
     } ]
   } ],
   "launchDescriptor" : {


### PR DESCRIPTION
The `handlers` key was indented one level too deep in this module descriptor.