### PR TITLE
FOLIO-2639: Bump hello-vertx dependencies

### DIFF
--- a/.github/workflows/hello-vertx.yml
+++ b/.github/workflows/hello-vertx.yml
@@ -1,0 +1,29 @@
+name: hello-vertx
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start Okapi
+        run: |
+          docker create --name okapi folioorg/okapi
+          docker cp okapi:/usr/verticles/okapi-core-fat.jar okapi-core-fat.jar
+          docker rm -f okapi
+          java -jar okapi-core-fat.jar dev &
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: temurin
+          cache: maven
+      - name: Okapi health
+        run: curl --retry 30 --retry-delay 1 --retry-connrefused -sS http://localhost:9130/_/proxy/health
+      - run: cd hello-vertx; ./runhello.sh
+

--- a/.github/workflows/hello-vertx.yml
+++ b/.github/workflows/hello-vertx.yml
@@ -18,11 +18,10 @@ jobs:
           docker rm -f okapi
           java -jar okapi-core-fat.jar dev &
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/cache@v2
         with:
-          java-version: 11
-          distribution: temurin
-          cache: maven
+          path: ~/.m2/repository
+          key: hello-vertx
       - name: Okapi health
         run: curl --retry 30 --retry-delay 1 --retry-connrefused -sS http://localhost:9130/_/proxy/health
       - run: cd hello-vertx; ./runhello.sh

--- a/hello-vertx/Dockerfile
+++ b/hello-vertx/Dockerfile
@@ -6,18 +6,15 @@
 #   docker run -t -i -p 8080:8080 folio-hello-module
 ###
 
-FROM java:8
+FROM folioci/alpine-jre-openjdk11:latest
 
 ENV VERTICLE_FILE folio-hello-vertx-fat.jar
 
 # Set the location of the verticles
 ENV VERTICLE_HOME /usr/verticles
 
-EXPOSE 8080
-
 # Copy your fat jar to the container
-COPY target/$VERTICLE_FILE $VERTICLE_HOME/module.jar
+COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
 
-# Launch the verticle
-WORKDIR $VERTICLE_HOME
-ENTRYPOINT ["java", "-jar", "module.jar"]
+# Expose this port locally in the container.
+EXPOSE 8080

--- a/hello-vertx/README.md
+++ b/hello-vertx/README.md
@@ -61,7 +61,7 @@ See that it says "BUILD SUCCESS" near the end.
 Build the docker container with:
 
 ```sh
-docker build -t docker.ci.folio.org/folio-hello-module .
+docker build -t folio-hello-module .
 ```
 
 Test that it runs with:

--- a/hello-vertx/pom.xml
+++ b/hello-vertx/pom.xml
@@ -18,61 +18,62 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx-version>3.5.4</vertx-version>
     <docker.registry>docker.indexdata.com:5000</docker.registry>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.folio.okapi</groupId>
-      <artifactId>okapi-common</artifactId>
-      <version>2.23.0</version>
-    </dependency>
-    <!-- logging see http://www.slf4j.org/legacy.html -->
-    <!-- we use SLF4J for our logging interface -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.18</version>
-    </dependency>
-    <!-- we use log4j as our logging implementation -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.13</version>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
-    <!-- include slf4j bridges to proxy all logging from library deps to our logging impl -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.18</version>
-    </dependency>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>4.2.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.14.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
+  <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx-version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.folio.okapi</groupId>
+      <artifactId>okapi-common</artifactId>
+      <version>4.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+
+    <!-- test dependencies -->
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx-version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -81,16 +82,16 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
+          <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>filter-descriptor-inputs</id>
@@ -148,7 +149,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -167,6 +168,14 @@
               </transformers>
               <artifactSet/>
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/hello-vertx/src/main/resources/log4j.properties
+++ b/hello-vertx/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-#log4j.rootLogger=INFO, CONSOLE
-log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/hello-vertx/src/main/resources/log4j2.properties
+++ b/hello-vertx/src/main/resources/log4j2.properties
@@ -1,0 +1,18 @@
+status = error
+name = PropertiesConfig
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = debug
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+rootLogger.level = debug
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
https://issues.folio.org/browse/FOLIO-2639

This updates dependencies for the hello-vertx sub-project only.

Update from Java 8 to Java 11.
Update base docker container from Java:8 to folioci/alpine-jre-openjdk11:latest.
Update Vert.x from 3.5.4 to 4.2.1.
Update logging from SLF4J to log4j.
Update okapi-common from 2.23.0 to 4.9.0.
Update junit from 4.12 to 4.13.2.
Update maven-compiler-plugin from 3.3 to 3.8.1.
Update maven-resources-plugin from 3.0.1 to 3.1.0.
Update maven-shade-plugin from 2.4 to 3.2.4.

This fixes several security issues, most notable
* log4j https://nvd.nist.gov/vuln/detail/CVE-2019-17571
* junit https://nvd.nist.gov/vuln/detail/CVE-2020-15250
* okapi-common/maven https://nvd.nist.gov/vuln/detail/CVE-2021-26291 = https://issues.folio.org/browse/FOLIO-3045