### PR TITLE
Alpine Perl

### DIFF
--- a/simple-perl/Dockerfile
+++ b/simple-perl/Dockerfile
@@ -6,10 +6,14 @@
 #   docker run -t -i -p 8080:8080 folio-simple-perl-module
 ###
 
-FROM perl:slim
+FROM alpine
 
-RUN apt-get update && apt-get -y install libnet-server-perl libjson-perl libcgi-pm-perl libmodule-build-perl libwww-perl
-ENV PERL5LIB /usr/share/perl5
+RUN apk add --no-cache perl perl-net-server perl-json perl-cgi perl-lwp-useragent-determined
+
+# or:
+#FROM perl:slim
+#RUN apt-get update && apt-get -y install libnet-server-perl libjson-perl libcgi-pm-perl libmodule-build-perl libwww-perl
+#ENV PERL5LIB /usr/share/perl5
 
 # Set the location of the script
 ENV PERL_HOME /usr/okapi


### PR DESCRIPTION
Switch from perl:slim container to Alpine container.

This reduces the number of vulnerabilities:
https://snyk.io/test/docker/debian:bullseye-slim
https://snyk.io/test/docker/alpine
Most notable issues:
https://nvd.nist.gov/vuln/detail/CVE-2022-23219
https://nvd.nist.gov/vuln/detail/CVE-2022-23218
https://nvd.nist.gov/vuln/detail/CVE-2021-33574
https://nvd.nist.gov/vuln/detail/CVE-2020-16156

This also reduces the container size from 224 MB to 43 MB.